### PR TITLE
Fix rock layer depths and update strip size

### DIFF
--- a/include/geometry/Cavern.hh
+++ b/include/geometry/Cavern.hh
@@ -40,7 +40,7 @@ constexpr auto DetectorLength = 40*m;
 constexpr auto DetectorRadius = 11*m;
 constexpr auto DetectorHeight = 11.3*m;
 constexpr auto TotalHeight    = 34.9*m;
-constexpr auto BaseDepth      = 92.58*m - 1.602*m;
+constexpr auto BaseDepth      = 92.58*m;
 constexpr auto TopDepth       = BaseDepth - TotalHeight;
 constexpr auto CenterDepth    = BaseDepth - 0.5 * TotalHeight;
 //----------------------------------------------------------------------------------------------

--- a/include/geometry/Earth.hh
+++ b/include/geometry/Earth.hh
@@ -43,12 +43,13 @@ struct Material {
 //----------------------------------------------------------------------------------------------
 
 //__Earth Layer Sizes___________________________________________________________________________
-constexpr auto LayerWidthX    = 82500.0L*cm;
-constexpr auto LayerWidthY    = 82500.0L*cm;
-constexpr auto SandstoneDepth =  4530.0L*cm;
-constexpr auto MarlDepth      =  1825.0L*cm;
-constexpr auto MixDepth       =  3645.0L*cm;
-constexpr auto TotalDepth     = SandstoneDepth + MarlDepth + MixDepth;
+constexpr auto LayerWidthX     = 82500.0L*cm;
+constexpr auto LayerWidthY     = 82500.0L*cm;
+constexpr auto BufferZoneDepth =     1.602*m;
+constexpr auto SandstoneDepth  =  4530.0L*cm - BufferZoneDepth;
+constexpr auto MarlDepth       =  1825.0L*cm;
+constexpr auto MixDepth        =  3645.0L*cm;
+constexpr auto TotalDepth      = SandstoneDepth + MarlDepth + MixDepth;
 //----------------------------------------------------------------------------------------------
 
 //__Earth Logical Volumes_______________________________________________________________________

--- a/include/geometry/Prototype.hh
+++ b/include/geometry/Prototype.hh
@@ -161,7 +161,7 @@ public:
   constexpr static auto PadSpacingX = PadWidth + 1*mm;
   constexpr static auto PadSpacingY = PadHeight;
 
-  constexpr static auto StripHeight     =  67.5*mm;
+  constexpr static auto StripHeight     =  67.6*mm;
   constexpr static auto StripWidth      = 616.5*mm;
   constexpr static auto StripDepth      =     2*mm;
 

--- a/src/geometry/Cavern.cc
+++ b/src/geometry/Cavern.cc
@@ -119,8 +119,8 @@ G4VPhysicalVolume* Construct(G4LogicalVolume* world) {
     Construction::PlaceVolume(Earth::SandstoneVolume(), earth, Earth::SandstoneTransform());
   }
 
-  Construction::PlaceVolume(RingVolume(), earth,
-    G4Translate3D(0, 0, -0.5 * Earth::TotalDepth + CenterDepth + 0.5 * TotalHeight - DetectorHeight)
+  Construction::PlaceVolume(RingVolume(), world,
+    G4Translate3D(0, 0, BaseDepth - DetectorHeight)
       * Construction::Rotate(0, 1, 0, 90*deg));
   return Construction::PlaceVolume(earth, world, Earth::Transform());
 }

--- a/src/geometry/Earth.cc
+++ b/src/geometry/Earth.cc
@@ -85,7 +85,7 @@ G4LogicalVolume* MixVolume() {
 
 //__Earth Transformations_______________________________________________________________________
 const G4Translate3D Transform() {
-  return G4Translate3D(0, 0, 0.5L * TotalDepth);
+  return G4Translate3D(0, 0, 0.5L * TotalDepth + BufferZoneDepth);
 }
 const G4Translate3D SandstoneTransform() {
   return G4Translate3D(0, 0, 0.5L * (SandstoneDepth - TotalDepth));

--- a/src/geometry/prototype/Prototype.cc
+++ b/src/geometry/prototype/Prototype.cc
@@ -238,8 +238,9 @@ G4VPhysicalVolume* Detector::Construct(G4LogicalVolume* world) {
       _rpcs.push_back(rpc);
   }
 
+  const auto buffer_zone_depth = 1.602*m;
   return Construction::PlaceVolume(DetectorVolume, world,
-    G4Translate3D(-250*cm, 7*cm, -0.5 * total_outer_box_height));
+    G4Translate3D(-250*cm, 7*cm, -0.5 * total_outer_box_height + buffer_zone_depth));
 }
 //----------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Okay, I think I've got it all worked out now. The bottom of the test stand is now sitting at z=1.602 m instead of zero. The cavern floor is at z=92.58 m, and the DetectorRing is at z=81.28 m. There's 45.3 m - 1.602 m = 43.698 m of Sandstone and 18.25 m of Marl, which leaves 17.73 m of Mix between the test stand and the IP. If that seems right, then everything should be good.