### PR TITLE
require c++14 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ project(MATHUSLA_MU)
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 
+set(CMAKE_CXX_STANDARD 14)
+
 find_package(Geant4  REQUIRED gdml ui_all vis_all)
 find_package(Pythia8 REQUIRED)
 find_package(ROOT    REQUIRED)


### PR DESCRIPTION
C++14 is necessary in order to use `auto` in lambda parameter lists in src/physics/Particle.cc. CMake (for me at least) seems to default to C++11 unless this is set.