### PR TITLE
fix help text

### DIFF
--- a/src/util/command_line_parser.cc
+++ b/src/util/command_line_parser.cc
@@ -138,7 +138,11 @@ void _print_help_message(const std::string& argv0,
   for (const auto& option : options) {
     if (option == help) continue;
 
-    std::cout << "  -" << option->short_name;
+    std::cout << "  ";
+    if (option->short_name)
+      std::cout << "-" << option->short_name;
+    else
+      std::cout << "  ";
     if (!option->long_name.empty())
       std::cout << " --" << option->long_name;
     if (!option->description.empty()) {


### PR DESCRIPTION
Some of the command line options don't have short names (e.g., `-s` for `--script` but nothing for `--save-all`). This is indicated by a `char` of 0 in the corresponding option in command_line_parser, but this `NUL` still gets printed as an option specifier in the help text (it just looks like a lone dash, `-`). This is clearly misleading (and it messes up the text alignment...). Now the short option section will just be skipped with the appropriate number of spaces.

See:
```
 MATHUSLA Muon Simulation  build/simulation [args]
  -g --gen          : Generator
  -d --det          : Detector
  - --shift        : Shift Last Earth Layer
  -o --out          : Data Output Directory
  -E --export       : Export Output Directory
  -s --script       : Custom Script
  -e --events       : Event Count
  - --save_all     : Save All Generator Events
  -v --vis          : Visualization
  -q --quiet        : Quiet Mode
  -j --threads      : Multi-Threading Mode: Specify Optional number of threads (default: 2)
```
vs.
```
 MATHUSLA Muon Simulation  build/simulation [args]
  -g --gen          : Generator
  -d --det          : Detector
     --shift        : Shift Last Earth Layer
  -o --out          : Data Output Directory
  -E --export       : Export Output Directory
  -s --script       : Custom Script
  -e --events       : Event Count
     --save_all     : Save All Generator Events
  -v --vis          : Visualization
  -q --quiet        : Quiet Mode
  -j --threads      : Multi-Threading Mode: Specify Optional number of threads (default: 2)
```