### PR TITLE
remove single-threaded mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ project(MATHUSLA_MU)
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 
-find_package(Geant4  REQUIRED gdml ui_all vis_all)
+find_package(Geant4  REQUIRED multithreaded gdml ui_all vis_all)
 find_package(Pythia8 REQUIRED)
 find_package(ROOT    REQUIRED)
 

--- a/src/action/RunAction.cc
+++ b/src/action/RunAction.cc
@@ -141,19 +141,17 @@ void RunAction::EndOfRunAction(const G4Run*) {
       return;
     auto file = TFile::Open(_path.c_str(), "UPDATE");
     if (file && !file->IsZombie()) {
-      #ifdef G4MULTITHREADED
-        file->cd();
-        auto chain = new TChain(Construction::Builder::GetDetectorDataName().c_str());
-        for (const auto& tag : _worker_tags)
-          chain->Add((_prefix + tag).c_str());
+      file->cd();
+      auto chain = new TChain(Construction::Builder::GetDetectorDataName().c_str());
+      for (const auto& tag : _worker_tags)
+        chain->Add((_prefix + tag).c_str());
 
-        TTree* tree = chain;
-        file->cd();
-        auto clone_tree = tree->CloneTree();
-        if (clone_tree)
-          clone_tree->Write();
-        delete chain;
-      #endif
+      TTree* tree = chain;
+      file->cd();
+      auto clone_tree = tree->CloneTree();
+      if (clone_tree)
+        clone_tree->Write();
+      delete chain;
 
       util::io::remove_file(_prefix + _temp_path);
       for (const auto& tag : _worker_tags)

--- a/src/action/RunAction.cc
+++ b/src/action/RunAction.cc
@@ -141,17 +141,19 @@ void RunAction::EndOfRunAction(const G4Run*) {
       return;
     auto file = TFile::Open(_path.c_str(), "UPDATE");
     if (file && !file->IsZombie()) {
-      file->cd();
-      auto chain = new TChain(Construction::Builder::GetDetectorDataName().c_str());
-      for (const auto& tag : _worker_tags)
-        chain->Add((_prefix + tag).c_str());
+      #ifdef G4MULTITHREADED
+        file->cd();
+        auto chain = new TChain(Construction::Builder::GetDetectorDataName().c_str());
+        for (const auto& tag : _worker_tags)
+          chain->Add((_prefix + tag).c_str());
 
-      TTree* tree = chain;
-      file->cd();
-      auto clone_tree = tree->CloneTree();
-      if (clone_tree)
-        clone_tree->Write();
-      delete chain;
+        TTree* tree = chain;
+        file->cd();
+        auto clone_tree = tree->CloneTree();
+        if (clone_tree)
+          clone_tree->Write();
+        delete chain;
+      #endif
 
       util::io::remove_file(_prefix + _temp_path);
       for (const auto& tag : _worker_tags)

--- a/src/simulation.cc
+++ b/src/simulation.cc
@@ -76,31 +76,26 @@ int main(int argc, char* argv[]) {
   G4Random::setTheEngine(new CLHEP::RanecuEngine);
   G4Random::setTheSeed(time(nullptr));
 
-  #ifdef G4MULTITHREADED
-    if (thread_opt.argument) {
-      auto opt = std::string(thread_opt.argument);
-      if (opt == "on") {
-        thread_opt.count = 2;
-      } else if (opt == "off" || opt == "0") {
-        thread_opt.count = 1;
-      } else {
-        try {
-          thread_opt.count = std::stoi(opt);
-        } catch (...) {
-          thread_opt.count = 2;
-        }
-      }
-    } else if (!thread_opt.count) {
+  if (thread_opt.argument) {
+    auto opt = std::string(thread_opt.argument);
+    if (opt == "on") {
       thread_opt.count = 2;
+    } else if (opt == "off" || opt == "0") {
+      thread_opt.count = 1;
+    } else {
+      try {
+        thread_opt.count = std::stoi(opt);
+      } catch (...) {
+        thread_opt.count = 2;
+      }
     }
-    auto run = new G4MTRunManager;
-    run->SetNumberOfThreads(thread_opt.count);
-    std::cout << "Running " << thread_opt.count
-              << (thread_opt.count > 1 ? " Threads" : " Thread") << "\n";
-  #else
-    auto run = new G4RunManager;
-    std::cout << "Running in Single Threaded Mode.\n";
-  #endif
+  } else if (!thread_opt.count) {
+    thread_opt.count = 2;
+  }
+  auto run = new G4MTRunManager;
+  run->SetNumberOfThreads(thread_opt.count);
+  std::cout << "Running " << thread_opt.count
+            << (thread_opt.count > 1 ? " Threads" : " Thread") << "\n";
 
   run->SetPrintProgress(1000);
   run->SetRandomNumberStore(false);


### PR DESCRIPTION
In src/action/RunAction.cc, there's a reduction step at the end of a run that combines all the TTrees from the worker threads. This is great... if multithreading is enabled. Otherwise, in single-threaded mode, there are no temporary files to open, so trying to clone an empty TChain leads to a segfault.

This just encloses the multithreading-specific code in an `#ifdef`.