### PR TITLE
fix materials

### DIFF
--- a/include/geometry/Construction.hh
+++ b/include/geometry/Construction.hh
@@ -48,7 +48,10 @@ extern G4Element* S;
 extern G4Element* Ar;
 extern G4Material* Air;
 extern G4Material* Aluminum;
+extern G4Material* Bakelite;
+extern G4Material* Copper;
 extern G4Material* Iron;
+extern G4Material* PolystyreneFoam;
 } /* namespace Material */ /////////////////////////////////////////////////////////////////////
 
 //__Size of The World___________________________________________________________________________

--- a/include/geometry/Prototype.hh
+++ b/include/geometry/Prototype.hh
@@ -81,8 +81,8 @@ public:
 
   const static Info InfoArray[Count];
 
-  constexpr static auto Thickness = 1.15*mm;
-  constexpr static auto Spacing   =    0*mm;
+  constexpr static auto Thickness =  1.0*mm;
+  constexpr static auto Spacing   = 0.15*mm;
   constexpr static auto Depth     = 15.0*mm;
 
   constexpr static auto PMTRadius =  2.1*cm;
@@ -112,9 +112,8 @@ public:
   };
 
   struct Material {
-    static G4Material* Casing;
-    static G4Material* Pad;
     static G4Material* Gas;
+    static G4Material* PET;
     static void Define();
   private:
     Material();
@@ -148,6 +147,15 @@ public:
   constexpr static auto Width       = 1257*mm;
   constexpr static auto Depth       =   44*mm;
 
+  constexpr static auto AluminumDepth  = 200*um;
+  constexpr static auto BakeliteDepth  =   2*mm;
+  constexpr static auto CopperDepth    =  17*um;
+  constexpr static auto ThickFoamDepth =  15*mm;
+  constexpr static auto ThinFoamDepth  =   3*mm;
+  constexpr static auto ThickPETDepth  = 250*um;
+  constexpr static auto MediumPETDepth = 190*um;
+  constexpr static auto ThinPETDepth   =  50*um;
+
   constexpr static auto PadHeight    = 556.8*mm;
   constexpr static auto PadWidth     = 616.5*mm;
   constexpr static auto PadDepth     =     2*mm;
@@ -159,7 +167,7 @@ public:
   constexpr static auto PadSpacingX = PadWidth + 1*mm;
   constexpr static auto PadSpacingY = PadHeight;
 
-  constexpr static auto StripHeight     =  67.6*mm;
+  constexpr static auto StripHeight     =  69.6*mm;
   constexpr static auto StripWidth      = 616.5*mm;
   constexpr static auto StripDepth      =     2*mm;
 

--- a/src/geometry/Construction.cc
+++ b/src/geometry/Construction.cc
@@ -73,7 +73,10 @@ G4Element* Material::S = _nist->FindOrBuildElement("S");
 G4Element* Material::Ar = _nist->FindOrBuildElement("Ar");
 G4Material* Material::Air = _nist->FindOrBuildMaterial("G4_AIR");
 G4Material* Material::Aluminum = _nist->FindOrBuildMaterial("G4_Al");
+G4Material* Material::Bakelite = _nist->FindOrBuildMaterial("G4_BAKELITE");
+G4Material* Material::Copper = _nist->FindOrBuildMaterial("G4_Cu");
 G4Material* Material::Iron = _nist->FindOrBuildMaterial("G4_Fe");
+G4Material* Material::PolystyreneFoam = _nist->BuildMaterialWithNewDensity("PolystyreneFoam", "G4_POLYSTYRENE", 32.0*kg/m3);
 //----------------------------------------------------------------------------------------------
 
 //__Detector Messenger Directory Path___________________________________________________________

--- a/src/geometry/prototype/RPC.cc
+++ b/src/geometry/prototype/RPC.cc
@@ -46,17 +46,60 @@ RPC::Pad::Pad(int input_id) : id(input_id) {}
 
 //__RPC Constructor_____________________________________________________________________________
 RPC::RPC(int input_id) : _pads(), _id(input_id), _name("RPC" + std::to_string(1 + input_id)) {
-  _volume = Construction::BoxVolume(_name, Width, Height, Depth, Material::Casing);
+  _volume = Construction::BoxVolume(_name, Width, Height, Depth, Construction::Material::Air, Construction::BorderAttributes());
 
   const auto id_name = (_id < 9 ? "0" : "") + std::to_string(1 + _id);
+
+  auto aluminum_sheet = Construction::BoxVolume(_name + "_Aluminum", Width, Height, AluminumDepth, Construction::Material::Aluminum, Construction::CasingAttributes());
+  auto bakelite_sheet = Construction::BoxVolume(_name + "_Bakelite", Width, Height, BakeliteDepth, Construction::Material::Bakelite);
+  auto copper_strips = Construction::BoxVolume(_name + "_Copper", Width, Height, CopperDepth, Construction::Material::Copper);
+  auto thick_foam_layer = Construction::BoxVolume(_name + "_Foam", Width, Height, ThickFoamDepth, Construction::Material::PolystyreneFoam);
+  auto thin_foam_layer = Construction::BoxVolume(_name + "_Foam", Width, Height, ThinFoamDepth, Construction::Material::PolystyreneFoam);
+  auto thick_pet_film = Construction::BoxVolume(_name + "_PET", Width, Height, ThickPETDepth, Material::PET);
+  auto medium_pet_film = Construction::BoxVolume(_name + "_PET", Width, Height, MediumPETDepth, Material::PET);
+  auto thin_pet_film = Construction::BoxVolume(_name + "_PET", Width, Height, ThinPETDepth, Material::PET);
+
+  auto z_shift = -(StripDepth + BakeliteDepth) / 2.0;
+  Construction::PlaceVolume(bakelite_sheet, _volume, G4Translate3D(0.0, 0.0, z_shift));
+  z_shift -= (BakeliteDepth + CopperDepth) / 2.0;
+  Construction::PlaceVolume(copper_strips, _volume, G4Translate3D(0.0, 0.0, z_shift));
+  z_shift -= (CopperDepth + MediumPETDepth) / 2.0;
+  Construction::PlaceVolume(medium_pet_film, _volume, G4Translate3D(0.0, 0.0, z_shift));
+  z_shift -= (MediumPETDepth + ThinFoamDepth) / 2.0;
+  Construction::PlaceVolume(thin_foam_layer, _volume, G4Translate3D(0.0, 0.0, z_shift));
+  z_shift -= (ThinFoamDepth + ThinPETDepth) / 2.0;
+  Construction::PlaceVolume(thin_pet_film, _volume, G4Translate3D(0.0, 0.0, z_shift));
+  z_shift -= (ThinPETDepth + CopperDepth) / 2.0;
+  Construction::PlaceVolume(copper_strips, _volume, G4Translate3D(0.0, 0.0, z_shift));
+  z_shift -= (CopperDepth + AluminumDepth) / 2.0;
+  Construction::PlaceVolume(aluminum_sheet, _volume, G4Translate3D(0.0, 0.0, z_shift));
+  z_shift -= (AluminumDepth + ThickFoamDepth) / 2.0;
+  Construction::PlaceVolume(thick_foam_layer, _volume, G4Translate3D(0.0, 0.0, z_shift));
+  z_shift -= (ThickFoamDepth + AluminumDepth) / 2.0;
+  Construction::PlaceVolume(aluminum_sheet, _volume, G4Translate3D(0.0, 0.0, z_shift));
+
+  z_shift = (StripDepth + BakeliteDepth) / 2.0;
+  Construction::PlaceVolume(bakelite_sheet, _volume, G4Translate3D(0.0, 0.0, z_shift));
+  z_shift += (BakeliteDepth + ThickPETDepth) / 2.0;
+  Construction::PlaceVolume(thick_pet_film, _volume, G4Translate3D(0.0, 0.0, z_shift));
+  z_shift += (ThickPETDepth + ThinFoamDepth) / 2.0;
+  Construction::PlaceVolume(thin_foam_layer, _volume, G4Translate3D(0.0, 0.0, z_shift));
+  z_shift += (ThinFoamDepth + CopperDepth) / 2.0;
+  Construction::PlaceVolume(copper_strips, _volume, G4Translate3D(0.0, 0.0, z_shift));
+  z_shift += (CopperDepth + MediumPETDepth) / 2.0;
+  Construction::PlaceVolume(medium_pet_film, _volume, G4Translate3D(0.0, 0.0, z_shift));
+  z_shift += (MediumPETDepth + AluminumDepth) / 2.0;
+  Construction::PlaceVolume(aluminum_sheet, _volume, G4Translate3D(0.0, 0.0, z_shift));
+  z_shift += (AluminumDepth + ThickFoamDepth) / 2.0;
+  Construction::PlaceVolume(thick_foam_layer, _volume, G4Translate3D(0.0, 0.0, z_shift));
+  z_shift += (ThickFoamDepth + AluminumDepth) / 2.0;
+  Construction::PlaceVolume(aluminum_sheet, _volume, G4Translate3D(0.0, 0.0, z_shift));
 
   for (std::size_t pad_index{}; pad_index < PadsPerRPC; ++pad_index) {
     auto pad = new Pad(pad_index);
 
-    pad->lvolume = Construction::BoxVolume(
-      "PAD" + std::to_string(1 + pad_index),
-      PadWidth, PadHeight, PadDepth,
-      Material::Pad, Construction::CasingAttributes());
+    pad->lvolume = Construction::BoxVolume("PAD" + std::to_string(1 + pad_index),
+                                           PadWidth, PadHeight, PadDepth);
 
     const auto pad_name = id_name + (pad_index < 9 ? "0" : "") + std::to_string(1 + pad_index);
 
@@ -84,38 +127,38 @@ RPC::RPC(int input_id) : _pads(), _id(input_id), _name("RPC" + std::to_string(1 
 //----------------------------------------------------------------------------------------------
 
 //__RPC Material________________________________________________________________________________
-G4Material* RPC::Material::Casing = nullptr;
-G4Material* RPC::Material::Pad    = nullptr;
-G4Material* RPC::Material::Gas    = nullptr;
+G4Material* RPC::Material::Gas = nullptr;
+G4Material* RPC::Material::PET = nullptr;
 //----------------------------------------------------------------------------------------------
 
 //__Define RPC Material_________________________________________________________________________
 void RPC::Material::Define() {
-  Material::Casing = Construction::Material::Aluminum;
-  Material::Pad    = Construction::Material::Air;
-
-  auto C2H2F4 = new G4Material("C2H2F4", 4.1684*g/L, 3);
+  auto C2H2F4 = new G4Material("C2H2F4", 4.1684*g/L, 3, G4State::kStateGas, 298.15*kelvin);
   C2H2F4->AddElement(Construction::Material::C, 2);
   C2H2F4->AddElement(Construction::Material::H, 2);
   C2H2F4->AddElement(Construction::Material::F, 4);
 
-  /* NOTE: In case it becomes necessary:
+  auto isobutane = new G4Material("Isobutane", 2.4403*g/L, 2, G4State::kStateGas, 298.15*kelvin);
+  isobutane->AddElement(Construction::Material::C, 4);
+  isobutane->AddElement(Construction::Material::H, 10);
 
-  auto iso_C4H10 = new G4Material("iso-C4H10", 0*g/L, 2);
-  iso_C4H10->AddElement(Construction::Material::C, 4);
-  iso_C4H10->AddElement(Construction::Material::H, 10);
-
-  auto SF6 = new G4Material("SF6", 0*g/L, 2);
+  auto SF6 = new G4Material("SF6", 6.0380*g/L, 2, G4State::kStateGas, 298.15*kelvin);
   SF6->AddElement(Construction::Material::S, 1);
   SF6->AddElement(Construction::Material::F, 6);
-  */
 
-  auto argon = new G4Material("Argon", 1.635*g/L, 1);
+  auto argon = new G4Material("Argon", 1.6339*g/L, 1, G4State::kStateGas, 298.15*kelvin);
   argon->AddElement(Construction::Material::Ar, 1);
 
-  Material::Gas = new G4Material("Gas", 3.773*g/L, 2, G4State::kStateGas);
-  Material::Gas->AddMaterial(C2H2F4, 0.93);
-  Material::Gas->AddMaterial(argon,  0.07);
+  Material::Gas = new G4Material("Gas", 3.7269*g/L, 4, G4State::kStateGas, 298.15*kelvin);
+  Material::Gas->AddMaterial(C2H2F4,    0.85 * 0.952);
+  Material::Gas->AddMaterial(isobutane, 0.85 * 0.045);
+  Material::Gas->AddMaterial(SF6,       0.85 * 0.003);
+  Material::Gas->AddMaterial(argon,     0.15);
+
+  Material::PET = new G4Material("PET", 1.397*g/cm3, 3, G4State::kStateSolid);
+  Material::PET->AddElement(Construction::Material::C, 10);
+  Material::PET->AddElement(Construction::Material::H, 8);
+  Material::PET->AddElement(Construction::Material::O, 4);
 }
 //----------------------------------------------------------------------------------------------
 

--- a/src/geometry/prototype/RPC.cc
+++ b/src/geometry/prototype/RPC.cc
@@ -53,11 +53,11 @@ RPC::RPC(int input_id) : _pads(), _id(input_id), _name("RPC" + std::to_string(1 
   auto aluminum_sheet = Construction::BoxVolume(_name + "_Aluminum", Width, Height, AluminumDepth, Construction::Material::Aluminum, Construction::CasingAttributes());
   auto bakelite_sheet = Construction::BoxVolume(_name + "_Bakelite", Width, Height, BakeliteDepth, Construction::Material::Bakelite);
   auto copper_strips = Construction::BoxVolume(_name + "_Copper", Width, Height, CopperDepth, Construction::Material::Copper);
-  auto thick_foam_layer = Construction::BoxVolume(_name + "_Foam", Width, Height, ThickFoamDepth, Construction::Material::PolystyreneFoam);
-  auto thin_foam_layer = Construction::BoxVolume(_name + "_Foam", Width, Height, ThinFoamDepth, Construction::Material::PolystyreneFoam);
-  auto thick_pet_film = Construction::BoxVolume(_name + "_PET", Width, Height, ThickPETDepth, Material::PET);
-  auto medium_pet_film = Construction::BoxVolume(_name + "_PET", Width, Height, MediumPETDepth, Material::PET);
-  auto thin_pet_film = Construction::BoxVolume(_name + "_PET", Width, Height, ThinPETDepth, Material::PET);
+  auto thick_foam_layer = Construction::BoxVolume(_name + "_ThickFoam", Width, Height, ThickFoamDepth, Construction::Material::PolystyreneFoam);
+  auto thin_foam_layer = Construction::BoxVolume(_name + "_ThinFoam", Width, Height, ThinFoamDepth, Construction::Material::PolystyreneFoam);
+  auto thick_pet_film = Construction::BoxVolume(_name + "_ThickPET", Width, Height, ThickPETDepth, Material::PET);
+  auto medium_pet_film = Construction::BoxVolume(_name + "_MediumPET", Width, Height, MediumPETDepth, Material::PET);
+  auto thin_pet_film = Construction::BoxVolume(_name + "_ThinPET", Width, Height, ThinPETDepth, Material::PET);
 
   auto z_shift = -(StripDepth + BakeliteDepth) / 2.0;
   Construction::PlaceVolume(bakelite_sheet, _volume, G4Translate3D(0.0, 0.0, z_shift));

--- a/src/geometry/prototype/Scintillator.cc
+++ b/src/geometry/prototype/Scintillator.cc
@@ -156,7 +156,7 @@ void Scintillator::Material::Define() {
   Material::PMT = G4NistManager::Instance()->FindOrBuildMaterial("G4_C");
   Material::Casing = Construction::Material::Aluminum;
 
-  Material::Scintillator = new G4Material("Scintillator", 1.032*g/cm3, 2);
+  Material::Scintillator = new G4Material("Scintillator", 1.032*g/cm3, 2, G4State::kStateSolid);
   Material::Scintillator->AddElement(Construction::Material::C, 9);
   Material::Scintillator->AddElement(Construction::Material::H, 10);
 


### PR DESCRIPTION
The RPCs are currently simulated as a solid 4.4 cm block of aluminum, minus the 2 mm gas gap. This leads to horribly inaccurate energy losses, much larger than what is realistic considering that the RPC only has ~1 mm total of aluminum thickness. Most of the detector volume is polystyrene foam and the majority of the dense material is the 4 mm of bakelite surrounding the gas. I also updated the gas mixture to what was actually used at P1 (85% ATLAS RPC mixture, 15% argon).