### PR TITLE
remove ignored verbosity setting

### DIFF
--- a/scripts/settings/quiet
+++ b/scripts/settings/quiet
@@ -29,7 +29,7 @@
 
 /material/verbose 0
 
-/particle/property/verbose 0
+#/particle/property/verbose 0
 # 0 : silent
 # 1 : warnings
 # 2 : more

--- a/scripts/settings/verbose
+++ b/scripts/settings/verbose
@@ -29,7 +29,7 @@
 
 /material/verbose 0
 
-/particle/property/verbose 0
+#/particle/property/verbose 0
 # 0 : silent
 # 1 : warnings
 # 2 : more


### PR DESCRIPTION
I get this message every time I run:
```
G4WT0 > /particle/property/verbose 0
G4WT0 > Particle is not selected yet !! Command ignored.
```
Clearly this setting is not having any effect since it's ignored by Geant4. I've commented it out so that this warning doesn't appear anymore.