### PR TITLE
Allow initial particles to have zero momentum in basic and range generators

### DIFF
--- a/src/physics/Generator.cc
+++ b/src/physics/Generator.cc
@@ -206,7 +206,7 @@ void Generator::GenerateCommands() {
 
   _ui_pT = CreateCommand<Command::DoubleUnitArg>("pT", "Set Transverse Momentum.");
   _ui_pT->SetParameterName("pT", false, false);
-  _ui_pT->SetRange("pT > 0");
+  _ui_pT->SetRange("pT >= 0");
   _ui_pT->SetDefaultUnit("GeV/c");
   _ui_pT->SetUnitCandidates("eV/c keV/c MeV/c GeV/c");
   _ui_pT->AvailableForStates(G4State_PreInit, G4State_Idle);
@@ -223,7 +223,7 @@ void Generator::GenerateCommands() {
 
   _ui_ke = CreateCommand<Command::DoubleUnitArg>("ke", "Set Kinetic Energy.");
   _ui_ke->SetParameterName("ke", false, false);
-  _ui_ke->SetRange("ke > 0");
+  _ui_ke->SetRange("ke >= 0");
   _ui_ke->SetDefaultUnit("GeV");
   _ui_ke->SetUnitCandidates("eV keV MeV GeV");
   _ui_ke->AvailableForStates(G4State_PreInit, G4State_Idle);
@@ -240,7 +240,7 @@ void Generator::GenerateCommands() {
 
   _ui_p_mag = CreateCommand<Command::DoubleUnitArg>("p_mag", "Set Momentum Magnitude.");
   _ui_p_mag->SetParameterName("p_mag", false, false);
-  _ui_p_mag->SetRange("p_mag > 0");
+  _ui_p_mag->SetRange("p_mag >= 0");
   _ui_p_mag->SetDefaultUnit("GeV/c");
   _ui_p_mag->SetUnitCandidates("eV/c keV/c MeV/c GeV/c");
   _ui_p_mag->AvailableForStates(G4State_PreInit, G4State_Idle);

--- a/src/physics/RangeGenerator.cc
+++ b/src/physics/RangeGenerator.cc
@@ -52,14 +52,14 @@ RangeGenerator::RangeGenerator(const std::string& name,
 void RangeGenerator::GenerateCommands() {
   _ui_pT_min = CreateCommand<Command::DoubleUnitArg>("pT_min", "Set Minimum Transverse Momentum.");
   _ui_pT_min->SetParameterName("pT_min", false, false);
-  _ui_pT_min->SetRange("pT_min > 0");
+  _ui_pT_min->SetRange("pT_min >= 0");
   _ui_pT_min->SetDefaultUnit("GeV/c");
   _ui_pT_min->SetUnitCandidates("eV/c keV/c MeV/c GeV/c");
   _ui_pT_min->AvailableForStates(G4State_PreInit, G4State_Idle);
 
   _ui_pT_max = CreateCommand<Command::DoubleUnitArg>("pT_max", "Set Maximum Transverse Momentum.");
   _ui_pT_max->SetParameterName("pT_max", false, false);
-  _ui_pT_max->SetRange("pT_max > 0");
+  _ui_pT_max->SetRange("pT_max >= 0");
   _ui_pT_max->SetDefaultUnit("GeV/c");
   _ui_pT_max->SetUnitCandidates("eV/c keV/c MeV/c GeV/c");
   _ui_pT_max->AvailableForStates(G4State_PreInit, G4State_Idle);
@@ -86,14 +86,14 @@ void RangeGenerator::GenerateCommands() {
 
   _ui_ke_min = CreateCommand<Command::DoubleUnitArg>("ke_min", "Set Minimum Kinetic Energy.");
   _ui_ke_min->SetParameterName("ke_min", false, false);
-  _ui_ke_min->SetRange("ke_min > 0");
+  _ui_ke_min->SetRange("ke_min >= 0");
   _ui_ke_min->SetDefaultUnit("GeV");
   _ui_ke_min->SetUnitCandidates("eV keV MeV GeV");
   _ui_ke_min->AvailableForStates(G4State_PreInit, G4State_Idle);
 
   _ui_ke_max = CreateCommand<Command::DoubleUnitArg>("ke_max", "Set Maximum Kinetic Energy.");
   _ui_ke_max->SetParameterName("ke_max", false, false);
-  _ui_ke_max->SetRange("ke_max > 0");
+  _ui_ke_max->SetRange("ke_max >= 0");
   _ui_ke_max->SetDefaultUnit("GeV");
   _ui_ke_max->SetUnitCandidates("eV keV MeV GeV");
   _ui_ke_max->AvailableForStates(G4State_PreInit, G4State_Idle);


### PR DESCRIPTION
There's no reason not to allow generation of particles at rest, which is especially helpful for cosmic muon decay studies.