### PR TITLE
remove "Geant4/" from G4 includes

### DIFF
--- a/include/action.hh
+++ b/include/action.hh
@@ -20,12 +20,12 @@
 #define MU__ACTION_HH
 #pragma once
 
-#include <Geant4/G4VUserActionInitialization.hh>
-#include <Geant4/G4UserEventAction.hh>
-#include <Geant4/G4UserRunAction.hh>
-#include <Geant4/G4VUserPrimaryGeneratorAction.hh>
-#include <Geant4/G4Event.hh>
-#include <Geant4/G4Run.hh>
+#include <G4VUserActionInitialization.hh>
+#include <G4UserEventAction.hh>
+#include <G4UserRunAction.hh>
+#include <G4VUserPrimaryGeneratorAction.hh>
+#include <G4Event.hh>
+#include <G4Run.hh>
 
 #include "physics/Generator.hh"
 #include "ui.hh"

--- a/include/analysis.hh
+++ b/include/analysis.hh
@@ -23,7 +23,7 @@
 #include <vector>
 #include <unordered_map>
 
-#include <Geant4/g4root.hh>
+#include <g4root.hh>
 
 namespace MATHUSLA { namespace MU {
 

--- a/include/geometry/Construction.hh
+++ b/include/geometry/Construction.hh
@@ -19,17 +19,17 @@
 #define MU__GEOMETRY_CONSTRUCTION_HH
 #pragma once
 
-#include <Geant4/G4VSensitiveDetector.hh>
-#include <Geant4/G4VUserDetectorConstruction.hh>
-#include <Geant4/G4LogicalVolume.hh>
-#include <Geant4/G4VPhysicalVolume.hh>
-#include <Geant4/G4VisAttributes.hh>
-#include <Geant4/G4Transform3D.hh>
-#include <Geant4/G4Box.hh>
-#include <Geant4/G4Trap.hh>
-#include <Geant4/G4Tubs.hh>
-#include <Geant4/G4Material.hh>
-#include <Geant4/G4SystemOfUnits.hh>
+#include <G4VSensitiveDetector.hh>
+#include <G4VUserDetectorConstruction.hh>
+#include <G4LogicalVolume.hh>
+#include <G4VPhysicalVolume.hh>
+#include <G4VisAttributes.hh>
+#include <G4Transform3D.hh>
+#include <G4Box.hh>
+#include <G4Trap.hh>
+#include <G4Tubs.hh>
+#include <G4Material.hh>
+#include <G4SystemOfUnits.hh>
 
 #include "analysis.hh"
 #include "ui.hh"

--- a/include/geometry/Earth.hh
+++ b/include/geometry/Earth.hh
@@ -19,11 +19,11 @@
 #define MU__GEOMETRY_EARTH_HH
 #pragma once
 
-#include <Geant4/G4Material.hh>
-#include <Geant4/G4VPhysicalVolume.hh>
-#include <Geant4/G4LogicalVolume.hh>
-#include <Geant4/G4Transform3D.hh>
-#include <Geant4/G4SystemOfUnits.hh>
+#include <G4Material.hh>
+#include <G4VPhysicalVolume.hh>
+#include <G4LogicalVolume.hh>
+#include <G4Transform3D.hh>
+#include <G4SystemOfUnits.hh>
 
 namespace MATHUSLA { namespace MU {
 

--- a/include/geometry/Flat.hh
+++ b/include/geometry/Flat.hh
@@ -19,7 +19,7 @@
 #define MU__GEOMETRY_FLAT_HH
 #pragma once
 
-#include "Geant4/G4VSensitiveDetector.hh"
+#include "G4VSensitiveDetector.hh"
 
 #include "geometry/Construction.hh"
 #include "tracking.hh"

--- a/include/geometry/MuonMapper.hh
+++ b/include/geometry/MuonMapper.hh
@@ -19,7 +19,7 @@
 #define MU__GEOMETRY_MUONMAPPER_HH
 #pragma once
 
-#include "Geant4/G4VSensitiveDetector.hh"
+#include "G4VSensitiveDetector.hh"
 
 #include "geometry/Construction.hh"
 

--- a/include/geometry/Prototype.hh
+++ b/include/geometry/Prototype.hh
@@ -21,7 +21,7 @@
 
 #include <vector>
 
-#include "Geant4/G4VSensitiveDetector.hh"
+#include "G4VSensitiveDetector.hh"
 
 #include "geometry/Construction.hh"
 

--- a/include/physics/Generator.hh
+++ b/include/physics/Generator.hh
@@ -20,9 +20,9 @@
 #define MU__PHYSICS_GENERATOR_HH
 #pragma once
 
-#include <Geant4/G4Event.hh>
-#include <Geant4/G4PrimaryVertex.hh>
-#include <Geant4/G4PrimaryParticle.hh>
+#include <G4Event.hh>
+#include <G4PrimaryVertex.hh>
+#include <G4PrimaryParticle.hh>
 
 #include "analysis.hh"
 #include "ui.hh"

--- a/include/physics/Particle.hh
+++ b/include/physics/Particle.hh
@@ -20,8 +20,8 @@
 #define MU__PHYSICS_PARTICLE_HH
 #pragma once
 
-#include <Geant4/G4ThreeVector.hh>
-#include <Geant4/G4Event.hh>
+#include <G4ThreeVector.hh>
+#include <G4Event.hh>
 
 namespace MATHUSLA { namespace MU {
 

--- a/include/physics/Units.hh
+++ b/include/physics/Units.hh
@@ -20,9 +20,9 @@
 #define MU__PHYSICS_UNITS_HH
 #pragma once
 
-#include <Geant4/G4UnitsTable.hh>
-#include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4PhysicalConstants.hh>
+#include <G4UnitsTable.hh>
+#include <G4SystemOfUnits.hh>
+#include <G4PhysicalConstants.hh>
 
 namespace MATHUSLA { namespace MU {
 

--- a/include/tracking.hh
+++ b/include/tracking.hh
@@ -22,15 +22,15 @@
 
 #include <ostream>
 
-#include <Geant4/G4Allocator.hh>
-#include <Geant4/G4THitsCollection.hh>
-#include <Geant4/G4LorentzVector.hh>
-#include <Geant4/G4VHit.hh>
-#include <Geant4/G4Step.hh>
-#include <Geant4/G4Event.hh>
-#include <Geant4/G4HCofThisEvent.hh>
-#include <Geant4/G4VSensitiveDetector.hh>
-#include <Geant4/G4ParticleDefinition.hh>
+#include <G4Allocator.hh>
+#include <G4THitsCollection.hh>
+#include <G4LorentzVector.hh>
+#include <G4VHit.hh>
+#include <G4Step.hh>
+#include <G4Event.hh>
+#include <G4HCofThisEvent.hh>
+#include <G4VSensitiveDetector.hh>
+#include <G4ParticleDefinition.hh>
 
 #include "analysis.hh"
 #include "physics/Particle.hh"

--- a/include/ui.hh
+++ b/include/ui.hh
@@ -20,23 +20,23 @@
 #define MU__UI_HH
 #pragma once
 
-#include <Geant4/G4VMarker.hh>
-#include <Geant4/G4Circle.hh>
-#include <Geant4/G4VisAttributes.hh>
-#include <Geant4/G4VVisManager.hh>
-#include <Geant4/G4ThreeVector.hh>
-#include <Geant4/G4UIcommand.hh>
-#include <Geant4/G4UIdirectory.hh>
-#include <Geant4/G4UIcmdWithoutParameter.hh>
-#include <Geant4/G4UIcmdWithAString.hh>
-#include <Geant4/G4UIcmdWithABool.hh>
-#include <Geant4/G4UIcmdWithAnInteger.hh>
-#include <Geant4/G4UIcmdWithADouble.hh>
-#include <Geant4/G4UIcmdWith3Vector.hh>
-#include <Geant4/G4UIcmdWithADoubleAndUnit.hh>
-#include <Geant4/G4UIcmdWith3VectorAndUnit.hh>
-#include <Geant4/G4UImessenger.hh>
-#include <Geant4/G4UImanager.hh>
+#include <G4VMarker.hh>
+#include <G4Circle.hh>
+#include <G4VisAttributes.hh>
+#include <G4VVisManager.hh>
+#include <G4ThreeVector.hh>
+#include <G4UIcommand.hh>
+#include <G4UIdirectory.hh>
+#include <G4UIcmdWithoutParameter.hh>
+#include <G4UIcmdWithAString.hh>
+#include <G4UIcmdWithABool.hh>
+#include <G4UIcmdWithAnInteger.hh>
+#include <G4UIcmdWithADouble.hh>
+#include <G4UIcmdWith3Vector.hh>
+#include <G4UIcmdWithADoubleAndUnit.hh>
+#include <G4UIcmdWith3VectorAndUnit.hh>
+#include <G4UImessenger.hh>
+#include <G4UImanager.hh>
 
 namespace MATHUSLA { namespace MU {
 

--- a/src/action/ActionInitialization.cc
+++ b/src/action/ActionInitialization.cc
@@ -17,7 +17,7 @@
 
 #include "action.hh"
 
-#include <Geant4/tls.hh>
+#include <tls.hh>
 
 namespace MATHUSLA { namespace MU {
 

--- a/src/action/EventAction.cc
+++ b/src/action/EventAction.cc
@@ -17,8 +17,8 @@
 
 #include "action.hh"
 
-#include <Geant4/G4MTRunManager.hh>
-#include <Geant4/tls.hh>
+#include <G4MTRunManager.hh>
+#include <tls.hh>
 
 namespace MATHUSLA { namespace MU {
 

--- a/src/action/GeneratorAction.cc
+++ b/src/action/GeneratorAction.cc
@@ -19,7 +19,7 @@
 
 #include <unordered_map>
 
-#include <Geant4/tls.hh>
+#include <tls.hh>
 
 #include "geometry/Earth.hh"
 #include "geometry/Cavern.hh"

--- a/src/action/RunAction.cc
+++ b/src/action/RunAction.cc
@@ -22,10 +22,10 @@
 #include <ostream>
 #include <thread>
 
-#include <Geant4/G4Threading.hh>
-#include <Geant4/G4AutoLock.hh>
-#include <Geant4/G4MTRunManager.hh>
-#include <Geant4/tls.hh>
+#include <G4Threading.hh>
+#include <G4AutoLock.hh>
+#include <G4MTRunManager.hh>
+#include <tls.hh>
 
 #include <TFile.h>
 #include <TNamed.h>

--- a/src/analysis.cc
+++ b/src/analysis.cc
@@ -17,7 +17,7 @@
 
 #include "analysis.hh"
 
-#include <Geant4/tls.hh>
+#include <tls.hh>
 
 #include <TFile.h>
 #include <TNamed.h>

--- a/src/dump_geometry.cc
+++ b/src/dump_geometry.cc
@@ -1,8 +1,8 @@
-#include "Geant4/G4VPhysicalVolume.hh"
-#include "Geant4/G4ThreeVector.hh"
-#include "Geant4/G4RotationMatrix.hh"
-#include "Geant4/G4Trap.hh"
-#include "Geant4/G4Box.hh"
+#include "G4VPhysicalVolume.hh"
+#include "G4ThreeVector.hh"
+#include "G4RotationMatrix.hh"
+#include "G4Trap.hh"
+#include "G4Box.hh"
 
 #include "geometry/Construction.hh"
 

--- a/src/geometry/Cavern.cc
+++ b/src/geometry/Cavern.cc
@@ -17,9 +17,9 @@
 
 #include "geometry/Cavern.hh"
 
-#include <Geant4/G4IntersectionSolid.hh>
-#include <Geant4/G4UnionSolid.hh>
-#include <Geant4/G4SubtractionSolid.hh>
+#include <G4IntersectionSolid.hh>
+#include <G4UnionSolid.hh>
+#include <G4SubtractionSolid.hh>
 
 #include "geometry/Construction.hh"
 

--- a/src/geometry/Construction.cc
+++ b/src/geometry/Construction.cc
@@ -17,18 +17,18 @@
 
 #include "geometry/Construction.hh"
 
-#include <Geant4/G4SubtractionSolid.hh>
-#include <Geant4/G4GeometryManager.hh>
-#include <Geant4/G4GeometryTolerance.hh>
-#include <Geant4/G4LogicalVolumeStore.hh>
-#include <Geant4/G4PhysicalVolumeStore.hh>
-#include <Geant4/G4SDManager.hh>
-#include <Geant4/G4Colour.hh>
-#include <Geant4/G4SolidStore.hh>
-#include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4NistManager.hh>
-#include <Geant4/G4GDMLParser.hh>
-#include <Geant4/tls.hh>
+#include <G4SubtractionSolid.hh>
+#include <G4GeometryManager.hh>
+#include <G4GeometryTolerance.hh>
+#include <G4LogicalVolumeStore.hh>
+#include <G4PhysicalVolumeStore.hh>
+#include <G4SDManager.hh>
+#include <G4Colour.hh>
+#include <G4SolidStore.hh>
+#include <G4PVPlacement.hh>
+#include <G4NistManager.hh>
+#include <G4GDMLParser.hh>
+#include <tls.hh>
 
 #include "geometry/Box.hh"
 #include "geometry/Prototype.hh"

--- a/src/geometry/Earth.cc
+++ b/src/geometry/Earth.cc
@@ -17,8 +17,8 @@
 
 #include "geometry/Earth.hh"
 
-#include <Geant4/G4SubtractionSolid.hh>
-#include <Geant4/tls.hh>
+#include <G4SubtractionSolid.hh>
+#include <tls.hh>
 
 #include "geometry/Construction.hh"
 

--- a/src/geometry/MuonMapper.cc
+++ b/src/geometry/MuonMapper.cc
@@ -1,8 +1,8 @@
 #include "geometry/MuonMapper.hh"
 
-#include <Geant4/G4NistManager.hh>
-#include <Geant4/G4VProcess.hh>
-#include <Geant4/tls.hh>
+#include <G4NistManager.hh>
+#include <G4VProcess.hh>
+#include <tls.hh>
 
 #include "action.hh"
 #include "analysis.hh"

--- a/src/geometry/box/Box.cc
+++ b/src/geometry/box/Box.cc
@@ -1,7 +1,7 @@
 #include "geometry/Box.hh"
 
-#include <Geant4/G4SubtractionSolid.hh>
-#include <Geant4/tls.hh>
+#include <G4SubtractionSolid.hh>
+#include <tls.hh>
 
 #include "action.hh"
 #include "analysis.hh"

--- a/src/geometry/box/Scintillator.cc
+++ b/src/geometry/box/Scintillator.cc
@@ -1,7 +1,7 @@
 #include "geometry/Box.hh"
 
-#include <Geant4/G4SubtractionSolid.hh>
-#include <Geant4/tls.hh>
+#include <G4SubtractionSolid.hh>
+#include <tls.hh>
 
 namespace MATHUSLA { namespace MU {
 

--- a/src/geometry/flat/Flat.cc
+++ b/src/geometry/flat/Flat.cc
@@ -17,7 +17,7 @@
 
 #include "geometry/Flat.hh"
 
-#include <Geant4/tls.hh>
+#include <tls.hh>
 
 #include "geometry/Earth.hh"
 #include "tracking.hh"

--- a/src/geometry/flat/Layer.cc
+++ b/src/geometry/flat/Layer.cc
@@ -17,7 +17,7 @@
 
 #include "geometry/Flat.hh"
 
-#include <Geant4/tls.hh>
+#include <tls.hh>
 
 namespace MATHUSLA { namespace MU {
 

--- a/src/geometry/flat/Scintillator.cc
+++ b/src/geometry/flat/Scintillator.cc
@@ -17,9 +17,9 @@
 
 #include "geometry/Flat.hh"
 
-#include <Geant4/G4SubtractionSolid.hh>
-#include <Geant4/G4UnionSolid.hh>
-#include <Geant4/tls.hh>
+#include <G4SubtractionSolid.hh>
+#include <G4UnionSolid.hh>
+#include <tls.hh>
 
 namespace MATHUSLA { namespace MU {
 

--- a/src/geometry/prototype/Prototype.cc
+++ b/src/geometry/prototype/Prototype.cc
@@ -19,9 +19,9 @@
 
 #include <unordered_map>
 
-#include <Geant4/G4HCofThisEvent.hh>
-#include <Geant4/G4Step.hh>
-#include <Geant4/tls.hh>
+#include <G4HCofThisEvent.hh>
+#include <G4Step.hh>
+#include <tls.hh>
 
 #include "action.hh"
 #include "analysis.hh"

--- a/src/geometry/prototype/RPC.cc
+++ b/src/geometry/prototype/RPC.cc
@@ -17,7 +17,7 @@
 
 #include "geometry/Prototype.hh"
 
-#include <Geant4/tls.hh>
+#include <tls.hh>
 
 namespace MATHUSLA { namespace MU {
 

--- a/src/geometry/prototype/Scintillator.cc
+++ b/src/geometry/prototype/Scintillator.cc
@@ -19,12 +19,12 @@
 
 #include <cmath>
 
-#include <Geant4/G4SubtractionSolid.hh>
-#include <Geant4/G4UnionSolid.hh>
-#include <Geant4/G4Tubs.hh>
-#include <Geant4/G4VisAttributes.hh>
-#include <Geant4/G4NistManager.hh>
-#include <Geant4/tls.hh>
+#include <G4SubtractionSolid.hh>
+#include <G4UnionSolid.hh>
+#include <G4Tubs.hh>
+#include <G4VisAttributes.hh>
+#include <G4NistManager.hh>
+#include <tls.hh>
 
 #include "geometry/Construction.hh"
 

--- a/src/physics/CORSIKAReaderGenerator.cc
+++ b/src/physics/CORSIKAReaderGenerator.cc
@@ -18,10 +18,10 @@
 
 #include "physics/CORSIKAReaderGenerator.hh"
 
-#include <Geant4/G4Threading.hh>
-#include <Geant4/G4AutoLock.hh>
-#include <Geant4/G4MTRunManager.hh>
-#include <Geant4/tls.hh>
+#include <G4Threading.hh>
+#include <G4AutoLock.hh>
+#include <G4MTRunManager.hh>
+#include <tls.hh>
 
 #include <TFile.h>
 #include <TTree.h>

--- a/src/physics/FileReaderGenerator.cc
+++ b/src/physics/FileReaderGenerator.cc
@@ -3,7 +3,7 @@
 #include "physics/Particle.hh"
 #include "analysis.hh"
 
-#include <Geant4/G4AutoLock.hh>
+#include <G4AutoLock.hh>
 
 #include <string>
 #include <cstddef>

--- a/src/physics/Generator.cc
+++ b/src/physics/Generator.cc
@@ -22,8 +22,8 @@
 #include <limits>
 #include <ostream>
 
-#include <Geant4/Randomize.hh>
-#include <Geant4/G4ParticleTable.hh>
+#include <Randomize.hh>
+#include <G4ParticleTable.hh>
 
 #include "physics/Units.hh"
 #include "tracking.hh"

--- a/src/physics/Particle.cc
+++ b/src/physics/Particle.cc
@@ -18,9 +18,9 @@
 
 #include "physics/Particle.hh"
 
-#include <Geant4/G4ParticleDefinition.hh>
-#include <Geant4/G4ParticleTable.hh>
-#include <Geant4/G4SystemOfUnits.hh>
+#include <G4ParticleDefinition.hh>
+#include <G4ParticleTable.hh>
+#include <G4SystemOfUnits.hh>
 
 #include "geometry/Cavern.hh"
 

--- a/src/physics/RangeGenerator.cc
+++ b/src/physics/RangeGenerator.cc
@@ -20,8 +20,8 @@
 
 #include <ostream>
 
-#include <Geant4/Randomize.hh>
-#include <Geant4/tls.hh>
+#include <Randomize.hh>
+#include <tls.hh>
 
 #include "physics/Units.hh"
 

--- a/src/simulation.cc
+++ b/src/simulation.cc
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-#include <Geant4/G4MTRunManager.hh>
-#include <Geant4/FTFP_BERT.hh>
-#include <Geant4/G4StepLimiterPhysics.hh>
-#include <Geant4/G4UIExecutive.hh>
-#include <Geant4/G4VisExecutive.hh>
-#include <Geant4/tls.hh>
+#include <G4MTRunManager.hh>
+#include <FTFP_BERT.hh>
+#include <G4StepLimiterPhysics.hh>
+#include <G4UIExecutive.hh>
+#include <G4VisExecutive.hh>
+#include <tls.hh>
 
 #include "action.hh"
 #include "geometry/Construction.hh"

--- a/src/tracking.cc
+++ b/src/tracking.cc
@@ -19,9 +19,9 @@
 
 #include <iomanip>
 
-#include <Geant4/G4SDManager.hh>
-#include <Geant4/G4RunManager.hh>
-#include <Geant4/tls.hh>
+#include <G4SDManager.hh>
+#include <G4RunManager.hh>
+#include <tls.hh>
 
 #include "physics/Units.hh"
 #include "ui.hh"


### PR DESCRIPTION
Doing this was necessary to run from LXPLUS with an LCG release of Geant4. This also works for me locally, so for a standard installation of G4 it should be fine.