### PR TITLE
Change physics list from FTFP_BERT to Shielding

### DIFF
--- a/src/simulation.cc
+++ b/src/simulation.cc
@@ -16,7 +16,7 @@
  */
 
 #include <G4MTRunManager.hh>
-#include <FTFP_BERT.hh>
+#include <Shielding.hh>
 #include <G4StepLimiterPhysics.hh>
 #include <G4UIExecutive.hh>
 #include <G4VisExecutive.hh>
@@ -105,7 +105,7 @@ int main(int argc, char* argv[]) {
   if (shift_opt.argument)
     Earth::LastShift(std::stold(shift_opt.argument) * m);
 
-  auto physics = new FTFP_BERT;
+  auto physics = new Shielding;
   physics->RegisterPhysics(new G4StepLimiterPhysics);
   run->SetUserInitialization(physics);
 


### PR DESCRIPTION
As discussed in MATHUSLA weekly meeting on 22 January 2020. The Shielding physics list is actually based on FTFP_BERT, but it adds some high precision processes at low energy, especially for neutrons. These processes are probably at energies below anything that could create a track, but any differences caused by this change would provide a very crude estimate of simulation systematics.