### PR TITLE
update scintillator digitization threshold

### DIFF
--- a/scripts/digitize.py
+++ b/scripts/digitize.py
@@ -197,7 +197,7 @@ def digitize_tree(
 ):
     """"""
     if thresholds is None:
-        thresholds = {"scintillator": 0.69 * u.MeV, "rpc": 0.17 * u.keV}
+        thresholds = {"scintillator": 1.1 * u.MeV, "rpc": 0.17 * u.keV}
     output.cd()
     ctree.SetDirectory(output)
     for (event, fullevent) in map(get_event_components, root2array(path, treename)):


### PR DESCRIPTION
Increase the energy threshold after change in physics list. See https://gitlab.cern.ch/mproffit/test-stand-sim-deposit-study/blob/dd2634ebee7f11ca7774bd79aefaf670d6d19831/cosmic-muon-digitization-thresholds.ipynb for updated plots.